### PR TITLE
Eip 712 adjustements

### DIFF
--- a/extension/packages/nextjs/app/eip-712/page.tsx
+++ b/extension/packages/nextjs/app/eip-712/page.tsx
@@ -108,14 +108,27 @@ const Eip712: NextPage = () => {
   return (
     <div className="flex items-center flex-col flex-grow pt-10 px-8">
       <div className="flex flex-col gap-4 items-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">EIP-712</h1>
+          <div className="max-w-2xl">
+            EIP-712 defines a standard for hashing and signing typed structured
+            data in Ethereum. It enhances security and usability by enabling the
+            creation of more readable and secure signed messages, reducing the
+            risk of phishing attacks and user errors. For more details, visit
+            the{" "}
+            <Link
+              href="https://eips.ethereum.org/EIPS/eip-712"
+              className="underline font-bold text-nowrap"
+            >
+              EIP-712 specification
+            </Link>
+            .
+          </div>
+        </div>
+        <div className="divider" />
+
         <div className="text-xl font-bold">
-          Send message to Bob using{" "}
-          <Link
-            className="underline"
-            href="https://eips.ethereum.org/EIPS/eip-712"
-          >
-            EIP-712
-          </Link>
+          Send message to Bob using EIP-712
         </div>
         <input
           placeholder="Your name"
@@ -140,7 +153,7 @@ const Eip712: NextPage = () => {
           Sign
         </button>
         {signature && (
-          <div className="text-center">
+          <div className="text-center max-w-2xl">
             <div className="font-bold">Signature:</div>
             <div className="break-all">{signature}</div>
           </div>

--- a/extension/packages/nextjs/app/eip-712/page.tsx
+++ b/extension/packages/nextjs/app/eip-712/page.tsx
@@ -125,8 +125,15 @@ const Eip712: NextPage = () => {
             </a>
             .
           </div>
+
+        <div className="divider my-0" />
+        <div>
+            Get started by editing{" "}
+          <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all [word-spacing:-0.5rem] inline-block">
+            packages / nextjs / app / eip-712.tsx
+            </code>
         </div>
-        <div className="divider" />
+        <div className="divider my-0" />
 
         <div className="text-xl font-bold">
           Send message to Bob using EIP-712

--- a/extension/packages/nextjs/app/eip-712/page.tsx
+++ b/extension/packages/nextjs/app/eip-712/page.tsx
@@ -16,6 +16,7 @@ import { getParsedError, notification } from "~~/utils/scaffold-eth";
 const Eip712: NextPage = () => {
   const { address: connectedAddress } = useAccount();
   const [signature, setSignature] = useState<SignTypedDataReturnType>();
+  const [isLoading, setIsLoading] = useState(false);
   const { signTypedDataAsync } = useSignTypedData();
 
   const [name, setName] = useState("");
@@ -76,6 +77,8 @@ const Eip712: NextPage = () => {
       signer: connectedAddress,
     };
 
+    setIsLoading(true);
+
     try {
       const res = await fetch("/api/verify", {
         method: "POST",
@@ -91,6 +94,8 @@ const Eip712: NextPage = () => {
     } catch (err) {
       const errorMessage = getParsedError(err);
       notification.error(errorMessage);
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -148,7 +153,7 @@ const Eip712: NextPage = () => {
           Verify (frontend)
         </button>
         <button
-          className="btn btn-primary btn-sm"
+          className={`btn btn-primary btn-sm${isLoading ? " loading" : ""}`}
           onClick={verifyOnBackend}
           disabled={!signature}
         >

--- a/extension/packages/nextjs/app/eip-712/page.tsx
+++ b/extension/packages/nextjs/app/eip-712/page.tsx
@@ -167,10 +167,11 @@ const Eip712: NextPage = () => {
           Verify (frontend)
         </button>
         <button
-          className={`btn btn-primary btn-sm${isLoading ? " loading" : ""}`}
+          className={`btn btn-primary btn-sm`}
           onClick={verifyOnBackend}
-          disabled={!signature}
+          disabled={!signature || isLoading}
         >
+          {isLoading && <span className="loading loading-spinner" />}
           Verify (backend)
         </button>
       </div>

--- a/extension/packages/nextjs/app/eip-712/page.tsx
+++ b/extension/packages/nextjs/app/eip-712/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import type { NextPage } from "next";
 import { SignTypedDataReturnType } from "viem/accounts";
 import { useAccount, useSignTypedData, useVerifyTypedData } from "wagmi";
@@ -16,6 +15,8 @@ import { getParsedError, notification } from "~~/utils/scaffold-eth";
 const Eip712: NextPage = () => {
   const { address: connectedAddress } = useAccount();
   const [signature, setSignature] = useState<SignTypedDataReturnType>();
+  const [signedTypedData, setSignedTypedData] =
+    useState<Record<string, unknown>>();
   const [isLoading, setIsLoading] = useState(false);
   const { signTypedDataAsync } = useSignTypedData();
 
@@ -43,6 +44,7 @@ const Eip712: NextPage = () => {
     try {
       const signature = await signTypedDataAsync(typedData);
       setSignature(signature);
+      setSignedTypedData(typedData);
       return signature;
     } catch (e) {
       const errorMessage = getParsedError(e);
@@ -102,36 +104,35 @@ const Eip712: NextPage = () => {
   useEffect(() => {
     if (!connectedAddress) {
       setSignature(undefined);
+      setSignedTypedData(undefined);
     }
   }, [connectedAddress]);
 
   return (
     <div className="flex items-center flex-col flex-grow pt-10 px-8">
-      <div className="flex flex-col gap-4 items-center">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold">EIP-712</h1>
-          <div className="max-w-2xl">
-            EIP-712 defines a standard for hashing and signing typed structured
-            data in Ethereum. It enhances security and usability by enabling the
-            creation of more readable and secure signed messages, reducing the
-            risk of phishing attacks and user errors. For more details, visit
-            the{" "}
-            <a
-              target="_blank"
-              href="https://eips.ethereum.org/EIPS/eip-712"
-              className="underline font-bold text-nowrap"
-            >
-              EIP-712 specification
-            </a>
-            .
-          </div>
+      <div className="flex flex-col gap-4 items-center text-center">
+        <h1 className="text-2xl font-bold">EIP-712</h1>
+        <div className="max-w-2xl">
+          EIP-712 defines a standard for hashing and signing typed structured
+          data in Ethereum. It enhances security and usability by enabling the
+          creation of more readable and secure signed messages, reducing the
+          risk of phishing attacks and user errors. For more details, visit the{" "}
+          <a
+            target="_blank"
+            href="https://eips.ethereum.org/EIPS/eip-712"
+            className="underline font-bold text-nowrap"
+          >
+            EIP-712 specification
+          </a>
+          .
+        </div>
 
         <div className="divider my-0" />
         <div>
-            Get started by editing{" "}
+          Get started by editing{" "}
           <code className="italic bg-base-300 text-base font-bold max-w-full break-words break-all [word-spacing:-0.5rem] inline-block">
             packages / nextjs / app / eip-712.tsx
-            </code>
+          </code>
         </div>
         <div className="divider my-0" />
 
@@ -160,12 +161,43 @@ const Eip712: NextPage = () => {
         >
           Sign
         </button>
+
+        <details className="collapse collapse-arrow bg-base-300 !max-w-full">
+          <input type="checkbox" className="hidden" />
+          <summary className="collapse-title font-bold">
+            Current typed data
+          </summary>
+          <div className="collapse-content text-start">
+            <pre className="break-all">
+              {JSON.stringify(typedData, undefined, 2)}
+            </pre>
+          </div>
+        </details>
+
+        {signature && signedTypedData && (
+          <details className="collapse collapse-arrow bg-base-300">
+            <input type="checkbox" className="hidden" />
+            <summary className="collapse-title font-bold">
+              Signed typed data
+            </summary>
+            <div className="collapse-content text-start">
+              <pre>{JSON.stringify(signedTypedData, undefined, 2)}</pre>
+            </div>
+          </details>
+        )}
+
         {signature && (
-          <div className="text-center max-w-2xl">
+          <div className="text-center max-w-2xl bg-base-300 p-4 rounded-2xl">
             <div className="font-bold">Signature:</div>
             <div className="break-all">{signature}</div>
           </div>
         )}
+
+        <div className="max-w-2xl">
+          To successfully verify current typed data and signed typed data must
+          be equal. Check <code className="font-bold">message.from.name</code>{" "}
+          and <code className="font-bold">message.contents</code>
+        </div>
         <button
           className="btn btn-primary btn-sm"
           onClick={verifyOnFrontend}

--- a/extension/packages/nextjs/app/eip-712/page.tsx
+++ b/extension/packages/nextjs/app/eip-712/page.tsx
@@ -116,12 +116,13 @@ const Eip712: NextPage = () => {
             creation of more readable and secure signed messages, reducing the
             risk of phishing attacks and user errors. For more details, visit
             the{" "}
-            <Link
+            <a
+              target="_blank"
               href="https://eips.ethereum.org/EIPS/eip-712"
               className="underline font-bold text-nowrap"
             >
               EIP-712 specification
-            </Link>
+            </a>
             .
           </div>
         </div>

--- a/extension/packages/nextjs/app/eip-712/page.tsx
+++ b/extension/packages/nextjs/app/eip-712/page.tsx
@@ -120,7 +120,7 @@ const Eip712: NextPage = () => {
         />
         <textarea
           placeholder="Your message"
-          className="textarea textarea-bordered rounded-lg w-full sm:w-96"
+          className="textarea textarea-bordered rounded-lg w-full sm:w-96 text-base"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
         />


### PR DESCRIPTION
fixes #4 

Current version: 

https://github.com/scaffold-eth/create-eth-extensions/assets/25638585/a5283272-5b5c-4450-ae43-ad3c68ace78a

Some notes
>  Same text size on input / textarea

FIxed. Not sure why, but on Daisy UI Input and Textarea font sizes are different.

> Loading button / spinner when sending the request (specially backend)

I added loading only for backend verification, and its slow only for first verification. Regarding frontend verification, it works using `useVerifyTypedData` hook and it's fast. So I think we don't need it for frontend button. Example of using `isLoading` from the hook

https://github.com/scaffold-eth/create-eth-extensions/assets/25638585/65d61791-98aa-4cd0-907b-b78f3f33c448

>  Have some info about EIP 712 in the page (a paragraph with a small description and a link to https://eips.ethereum.org/EIPS/eip-712 and hinting to check the eip-712/page.tsx). We can tinker in the PR (deciding the text, etc)

I added it to the top of the page. Also thought about just adding to tooltip, but in Daisy UI only text can be added there (without links, jsx etc)

Also, there are two different fail messages for frontend and backend. Because backend error is parsed, but on frontend `useVerifyTypedData` returns only `true` or `false` and no error when `false`. We can adjust error messages but not sure it's necessary

<img width="710" alt="Снимок экрана 2024-06-17 в 12 44 32" src="https://github.com/scaffold-eth/create-eth-extensions/assets/25638585/3a024dc9-b5e6-4cc4-9cf7-638acf023aa9">


To test
```
yarn cli -e scaffold-eth/create-eth-extensions:eip-712-adjustements
```