### PR TITLE
fix: change sign message

### DIFF
--- a/extension/packages/nextjs/app/eip-712/page.tsx
+++ b/extension/packages/nextjs/app/eip-712/page.tsx
@@ -152,7 +152,10 @@ const Eip712: NextPage = () => {
           onChange={(e) => setMessage(e.target.value)}
         />
 
-        {!connectedAddress && <span>⚠️ Connect wallet to sign data</span>}
+        <span>
+          Use Metamask or another wallet supporting
+          &quot;eth_signTypedData_v4&quot; to review typed data before signing.
+        </span>
 
         <button
           className="btn btn-primary btn-sm"


### PR DESCRIPTION
Changes message before sign button. Showing it without condition because it's better to show it even when burner-wallet connected

<img width="942" alt="image" src="https://github.com/scaffold-eth/create-eth-extensions/assets/25638585/3f28f010-faad-42f9-a4f9-4c1e12a6fb41">
