### PR TITLE
Randao random extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,21 @@
-# 🔌 create-eth Extensions
+# Randao Random Generator Extension for Scaffold-ETH 2
 
-This repository holds all the BG curated extensions for [create-eth](https://github.com/scaffold-eth/create-eth), so you can extend the functionality of your Scaffold-ETH project.
+This extension shows how to use on-chain randomness using RANDAO for truly on-chain unpredictable random sources.
 
-## Usage
+Ethereum PoS introduces randomness using block.mixHash (prevRandao). Look at [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) for more information.
+
+## Installation
 
 You can install any of the extensions in this repository by running the following command:
 
 ```bash
-npx create-eth@latest -e <extension-name>
+npx create-eth@latest -e randao
 ```
 
-## Available Extensions
+## 🚀 Setup extension
 
-- [subgraph](https://github.com/scaffold-eth/create-eth-extensions/tree/subgraph): This Scaffold-ETH 2 extension helps you build and test subgraphs locally for your contracts. It also enables interaction with the front-end and facilitates easy deployment to Subgraph Studio.
-- [eip-712](https://github.com/scaffold-eth/create-eth-extensions/tree/eip-712): An implementation of EIP-712, allowing you to send, sign, and verify typed messages in a user-friendly manner.
-- [ponder](https://github.com/scaffold-eth/create-eth-extensions/tree/ponder): This Scaffold-ETH 2 extension comes pre-configured with [ponder.sh](https://ponder.sh), providing an example to help you get started quickly.
-- [onchainkit](https://github.com/scaffold-eth/create-eth-extensions/tree/onchainkit): This Scaffold-ETH 2 extension comes pre-configured with [onchainkit](https://onchainkit.xyz/), providing an example to help you get started quickly.
-- [erc-20](https://github.com/scaffold-eth/create-eth-extensions/tree/erc-20): This extension introduces an ERC-20 token contract and demonstrates how to interact with it, including getting a holder balance and transferring tokens.
+Deploy your contract running `yarn deploy`
 
-## Create your own extension
+## Interact with the token
 
-You can extend Scaffold-ETH by creating your own extension. To do so, you need to create a new repository with the following structure:
-
-`ToDo`
-
-```bash
-npx create-eth@latest -e your-github-username/your-extension-repository:branch-name # branch-name is optional
-```
+Start the front-end with `yarn start` and go to the _/randao_ page to get more information and interact with your deployed RandomGenerator contract.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Ethereum PoS introduces randomness using block.mixHash (prevRandao). Look at [EI
 
 ## Installation
 
-You can install any of the extensions in this repository by running the following command:
-
 ```bash
 npx create-eth@latest -e randao
 ```
@@ -16,6 +14,6 @@ npx create-eth@latest -e randao
 
 Deploy your contract running `yarn deploy`
 
-## Interact with the token
+## Testing the random generator
 
 Start the front-end with `yarn start` and go to the _/randao_ page to get more information and interact with your deployed RandomGenerator contract.

--- a/extension/README.md.args.mjs
+++ b/extension/README.md.args.mjs
@@ -1,0 +1,15 @@
+export const extraContents = `## 🎲 Setup RANDAO Extension
+
+This extension shows how to use on-chain randomness using RANDAO for truly on-chain unpredictable random sources.
+
+Ethereum PoS introduces randomness using block.mixHash (prevRandao). Look at [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) for more information.
+
+### Setup
+
+Deploy your contract running \`\`\`yarn deploy\`\`\`
+
+### Testing the random generator
+
+Start the front-end with \`\`\`yarn start\`\`\` and go to the _/randao_ page to get more information and interact with your deployed RandomGenerator contract.
+
+`;

--- a/extension/packages/foundry/contracts/RLPReader.sol
+++ b/extension/packages/foundry/contracts/RLPReader.sol
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * @author Hamdi Allam hamdi.allam97@gmail.com
+ * Please reach out with any questions or concerns
+ */
+pragma solidity ^0.8.17;
+
+library RLPReader {
+  uint8 constant STRING_SHORT_START = 0x80;
+  uint8 constant STRING_LONG_START = 0xb8;
+  uint8 constant LIST_SHORT_START = 0xc0;
+  uint8 constant LIST_LONG_START = 0xf8;
+  uint8 constant WORD_SIZE = 32;
+
+  struct RLPItem {
+    uint len;
+    uint memPtr;
+  }
+
+  /*
+   * @param item RLP encoded bytes
+   */
+  function toRlpItem(bytes memory item) internal pure returns (RLPItem memory) {
+    uint memPtr;
+    assembly {
+      memPtr := add(item, 0x20)
+    }
+
+    return RLPItem(item.length, memPtr);
+  }
+
+  /*
+   * @param the RLP item.
+   */
+  function rlpLen(RLPItem memory item) internal pure returns (uint) {
+    return item.len;
+  }
+
+  /*
+   * @param the RLP item.
+   * @return (memPtr, len) pair: location of the item's payload in memory.
+   */
+  function payloadLocation(RLPItem memory item) internal pure returns (uint, uint) {
+    uint offset = _payloadOffset(item.memPtr);
+    uint memPtr = item.memPtr + offset;
+    uint len = item.len - offset; // data length
+    return (memPtr, len);
+  }
+
+  /*
+   * @param the RLP item.
+   */
+  function payloadLen(RLPItem memory item) internal pure returns (uint) {
+    (, uint len) = payloadLocation(item);
+    return len;
+  }
+
+  /*
+   * @param the RLP item containing the encoded list.
+   */
+  function toList(RLPItem memory item) internal pure returns (RLPItem[] memory) {
+    require(isList(item));
+
+    uint items = numItems(item);
+    RLPItem[] memory result = new RLPItem[](items);
+
+    uint memPtr = item.memPtr + _payloadOffset(item.memPtr);
+    uint dataLen;
+    for (uint i = 0; i < items; i++) {
+      dataLen = _itemLength(memPtr);
+      result[i] = RLPItem(dataLen, memPtr);
+      memPtr = memPtr + dataLen;
+    }
+
+    return result;
+  }
+
+  // @return indicator whether encoded payload is a list. negate this function call for isData.
+  function isList(RLPItem memory item) internal pure returns (bool) {
+    if (item.len == 0) return false;
+
+    uint8 byte0;
+    uint memPtr = item.memPtr;
+    assembly {
+      byte0 := byte(0, mload(memPtr))
+    }
+
+    if (byte0 < LIST_SHORT_START) return false;
+    return true;
+  }
+
+  /** RLPItem conversions into data types **/
+
+  function toUint(RLPItem memory item) internal pure returns (uint) {
+    require(item.len > 0 && item.len <= 33);
+
+    (uint memPtr, uint len) = payloadLocation(item);
+
+    uint result;
+    assembly {
+      result := mload(memPtr)
+
+      // shfit to the correct location if neccesary
+      if lt(len, 32) {
+        result := div(result, exp(256, sub(32, len)))
+      }
+    }
+
+    return result;
+  }
+
+  function toBytes(RLPItem memory item) internal pure returns (bytes memory) {
+    require(item.len > 0);
+
+    (uint memPtr, uint len) = payloadLocation(item);
+    bytes memory result = new bytes(len);
+
+    uint destPtr;
+    assembly {
+      destPtr := add(0x20, result)
+    }
+
+    copy(memPtr, destPtr, len);
+    return result;
+  }
+
+  /*
+   * Private Helpers
+   */
+
+  // @return number of payload items inside an encoded list.
+  function numItems(RLPItem memory item) private pure returns (uint) {
+    if (item.len == 0) return 0;
+
+    uint count = 0;
+    uint currPtr = item.memPtr + _payloadOffset(item.memPtr);
+    uint endPtr = item.memPtr + item.len;
+    while (currPtr < endPtr) {
+      currPtr = currPtr + _itemLength(currPtr); // skip over an item
+      count++;
+    }
+
+    return count;
+  }
+
+  // @return entire rlp item byte length
+  function _itemLength(uint memPtr) private pure returns (uint) {
+    uint itemLen;
+    uint byte0;
+    assembly {
+      byte0 := byte(0, mload(memPtr))
+    }
+
+    if (byte0 < STRING_SHORT_START) itemLen = 1;
+    else if (byte0 < STRING_LONG_START) itemLen = byte0 - STRING_SHORT_START + 1;
+    else if (byte0 < LIST_SHORT_START) {
+      assembly {
+        let byteLen := sub(byte0, 0xb7) // # of bytes the actual length is
+        memPtr := add(memPtr, 1) // skip over the first byte
+
+        /* 32 byte word size */
+        let dataLen := div(mload(memPtr), exp(256, sub(32, byteLen))) // right shifting to get the len
+        itemLen := add(dataLen, add(byteLen, 1))
+      }
+    } else if (byte0 < LIST_LONG_START) {
+      itemLen = byte0 - LIST_SHORT_START + 1;
+    } else {
+      assembly {
+        let byteLen := sub(byte0, 0xf7)
+        memPtr := add(memPtr, 1)
+
+        let dataLen := div(mload(memPtr), exp(256, sub(32, byteLen))) // right shifting to the correct length
+        itemLen := add(dataLen, add(byteLen, 1))
+      }
+    }
+
+    return itemLen;
+  }
+
+  // @return number of bytes until the data
+  function _payloadOffset(uint memPtr) private pure returns (uint) {
+    uint byte0;
+    assembly {
+      byte0 := byte(0, mload(memPtr))
+    }
+
+    if (byte0 < STRING_SHORT_START) return 0;
+    else if (byte0 < STRING_LONG_START || (byte0 >= LIST_SHORT_START && byte0 < LIST_LONG_START)) return 1;
+    else if (byte0 < LIST_SHORT_START)
+      // being explicit
+      return byte0 - (STRING_LONG_START - 1) + 1;
+    else return byte0 - (LIST_LONG_START - 1) + 1;
+  }
+
+  /*
+   * @param src Pointer to source
+   * @param dest Pointer to destination
+   * @param len Amount of memory to copy from the source
+   */
+  function copy(uint src, uint dest, uint len) private pure {
+    if (len == 0) return;
+
+    // copy as many word sizes as possible
+    for (; len >= WORD_SIZE; len -= WORD_SIZE) {
+      assembly {
+        mstore(dest, mload(src))
+      }
+
+      src += WORD_SIZE;
+      dest += WORD_SIZE;
+    }
+
+    if (len > 0) {
+      // left over bytes. Mask is used to remove unwanted bytes from the word
+      uint mask = 256 ** (WORD_SIZE - len) - 1;
+      assembly {
+        let srcpart := and(mload(src), not(mask)) // zero out src
+        let destpart := and(mload(dest), mask) // retrieve the bytes
+        mstore(dest, or(destpart, srcpart))
+      }
+    }
+  }
+}

--- a/extension/packages/foundry/contracts/RandomGenerator.sol
+++ b/extension/packages/foundry/contracts/RandomGenerator.sol
@@ -1,0 +1,36 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "./RLPReader.sol";
+
+contract RandomGenerator {
+  using RLPReader for RLPReader.RLPItem;
+  using RLPReader for bytes;
+
+  uint256 public constant futureBlocks = 2;
+
+  uint256 public blockNumber;
+  uint256 public randomNumber;
+
+  function generateRandomNumber() public {
+    blockNumber = block.number;
+  }
+
+  function getRandomNumber(bytes memory rlpBytes) public {
+    require(block.number >= blockNumber + futureBlocks, "Future block not reached");
+    require(block.number < blockNumber + futureBlocks + 256, "You miss the window");
+
+    RLPReader.RLPItem[] memory ls = rlpBytes.toRlpItem().toList();
+
+    bytes memory mixHash = ls[13].toBytes();
+
+    uint256 blockNumberFromHeader = ls[8].toUint();
+
+    require(blockNumberFromHeader == blockNumber + futureBlocks, "Wrong block");
+
+    require(blockhash(blockNumberFromHeader) == keccak256(rlpBytes), "Wrong block header");
+
+    bytes32 hash = keccak256(abi.encodePacked(mixHash, address(this), msg.sender));
+    randomNumber = uint256(hash);
+  }
+}

--- a/extension/packages/foundry/script/Deploy.s.sol.args.mjs
+++ b/extension/packages/foundry/script/Deploy.s.sol.args.mjs
@@ -1,0 +1,5 @@
+export const deploymentsScriptsImports = `import { DeployRandomGenerator } from "./DeployRandomGenerator.s.sol";`;
+export const deploymentsLogic = `
+    DeployRandomGenerator deployRandomGenerator = new DeployRandomGenerator();
+    deployRandomGenerator.run();
+`;

--- a/extension/packages/foundry/script/DeployRandomGenerator.s.sol
+++ b/extension/packages/foundry/script/DeployRandomGenerator.s.sol
@@ -1,0 +1,12 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "../contracts/RandomGenerator.sol";
+import "./DeployHelpers.s.sol";
+
+contract DeployRandomGenerator is ScaffoldETHDeploy {
+  function run() external ScaffoldEthDeployerRunner {
+    RandomGenerator randomGenerator = new RandomGenerator();
+    console.logString(string.concat("RandomGenerator deployed at: ", vm.toString(address(randomGenerator))));
+  }
+}

--- a/extension/packages/hardhat/contracts/RLPReader.sol
+++ b/extension/packages/hardhat/contracts/RLPReader.sol
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * @author Hamdi Allam hamdi.allam97@gmail.com
+ * Please reach out with any questions or concerns
+ */
+pragma solidity ^0.8.17;
+
+library RLPReader {
+  uint8 constant STRING_SHORT_START = 0x80;
+  uint8 constant STRING_LONG_START = 0xb8;
+  uint8 constant LIST_SHORT_START = 0xc0;
+  uint8 constant LIST_LONG_START = 0xf8;
+  uint8 constant WORD_SIZE = 32;
+
+  struct RLPItem {
+    uint len;
+    uint memPtr;
+  }
+
+  /*
+   * @param item RLP encoded bytes
+   */
+  function toRlpItem(bytes memory item) internal pure returns (RLPItem memory) {
+    uint memPtr;
+    assembly {
+      memPtr := add(item, 0x20)
+    }
+
+    return RLPItem(item.length, memPtr);
+  }
+
+  /*
+   * @param the RLP item.
+   */
+  function rlpLen(RLPItem memory item) internal pure returns (uint) {
+    return item.len;
+  }
+
+  /*
+   * @param the RLP item.
+   * @return (memPtr, len) pair: location of the item's payload in memory.
+   */
+  function payloadLocation(RLPItem memory item) internal pure returns (uint, uint) {
+    uint offset = _payloadOffset(item.memPtr);
+    uint memPtr = item.memPtr + offset;
+    uint len = item.len - offset; // data length
+    return (memPtr, len);
+  }
+
+  /*
+   * @param the RLP item.
+   */
+  function payloadLen(RLPItem memory item) internal pure returns (uint) {
+    (, uint len) = payloadLocation(item);
+    return len;
+  }
+
+  /*
+   * @param the RLP item containing the encoded list.
+   */
+  function toList(RLPItem memory item) internal pure returns (RLPItem[] memory) {
+    require(isList(item));
+
+    uint items = numItems(item);
+    RLPItem[] memory result = new RLPItem[](items);
+
+    uint memPtr = item.memPtr + _payloadOffset(item.memPtr);
+    uint dataLen;
+    for (uint i = 0; i < items; i++) {
+      dataLen = _itemLength(memPtr);
+      result[i] = RLPItem(dataLen, memPtr);
+      memPtr = memPtr + dataLen;
+    }
+
+    return result;
+  }
+
+  // @return indicator whether encoded payload is a list. negate this function call for isData.
+  function isList(RLPItem memory item) internal pure returns (bool) {
+    if (item.len == 0) return false;
+
+    uint8 byte0;
+    uint memPtr = item.memPtr;
+    assembly {
+      byte0 := byte(0, mload(memPtr))
+    }
+
+    if (byte0 < LIST_SHORT_START) return false;
+    return true;
+  }
+
+  /** RLPItem conversions into data types **/
+
+  function toUint(RLPItem memory item) internal pure returns (uint) {
+    require(item.len > 0 && item.len <= 33);
+
+    (uint memPtr, uint len) = payloadLocation(item);
+
+    uint result;
+    assembly {
+      result := mload(memPtr)
+
+      // shfit to the correct location if neccesary
+      if lt(len, 32) {
+        result := div(result, exp(256, sub(32, len)))
+      }
+    }
+
+    return result;
+  }
+
+  function toBytes(RLPItem memory item) internal pure returns (bytes memory) {
+    require(item.len > 0);
+
+    (uint memPtr, uint len) = payloadLocation(item);
+    bytes memory result = new bytes(len);
+
+    uint destPtr;
+    assembly {
+      destPtr := add(0x20, result)
+    }
+
+    copy(memPtr, destPtr, len);
+    return result;
+  }
+
+  /*
+   * Private Helpers
+   */
+
+  // @return number of payload items inside an encoded list.
+  function numItems(RLPItem memory item) private pure returns (uint) {
+    if (item.len == 0) return 0;
+
+    uint count = 0;
+    uint currPtr = item.memPtr + _payloadOffset(item.memPtr);
+    uint endPtr = item.memPtr + item.len;
+    while (currPtr < endPtr) {
+      currPtr = currPtr + _itemLength(currPtr); // skip over an item
+      count++;
+    }
+
+    return count;
+  }
+
+  // @return entire rlp item byte length
+  function _itemLength(uint memPtr) private pure returns (uint) {
+    uint itemLen;
+    uint byte0;
+    assembly {
+      byte0 := byte(0, mload(memPtr))
+    }
+
+    if (byte0 < STRING_SHORT_START) itemLen = 1;
+    else if (byte0 < STRING_LONG_START) itemLen = byte0 - STRING_SHORT_START + 1;
+    else if (byte0 < LIST_SHORT_START) {
+      assembly {
+        let byteLen := sub(byte0, 0xb7) // # of bytes the actual length is
+        memPtr := add(memPtr, 1) // skip over the first byte
+
+        /* 32 byte word size */
+        let dataLen := div(mload(memPtr), exp(256, sub(32, byteLen))) // right shifting to get the len
+        itemLen := add(dataLen, add(byteLen, 1))
+      }
+    } else if (byte0 < LIST_LONG_START) {
+      itemLen = byte0 - LIST_SHORT_START + 1;
+    } else {
+      assembly {
+        let byteLen := sub(byte0, 0xf7)
+        memPtr := add(memPtr, 1)
+
+        let dataLen := div(mload(memPtr), exp(256, sub(32, byteLen))) // right shifting to the correct length
+        itemLen := add(dataLen, add(byteLen, 1))
+      }
+    }
+
+    return itemLen;
+  }
+
+  // @return number of bytes until the data
+  function _payloadOffset(uint memPtr) private pure returns (uint) {
+    uint byte0;
+    assembly {
+      byte0 := byte(0, mload(memPtr))
+    }
+
+    if (byte0 < STRING_SHORT_START) return 0;
+    else if (byte0 < STRING_LONG_START || (byte0 >= LIST_SHORT_START && byte0 < LIST_LONG_START)) return 1;
+    else if (byte0 < LIST_SHORT_START)
+      // being explicit
+      return byte0 - (STRING_LONG_START - 1) + 1;
+    else return byte0 - (LIST_LONG_START - 1) + 1;
+  }
+
+  /*
+   * @param src Pointer to source
+   * @param dest Pointer to destination
+   * @param len Amount of memory to copy from the source
+   */
+  function copy(uint src, uint dest, uint len) private pure {
+    if (len == 0) return;
+
+    // copy as many word sizes as possible
+    for (; len >= WORD_SIZE; len -= WORD_SIZE) {
+      assembly {
+        mstore(dest, mload(src))
+      }
+
+      src += WORD_SIZE;
+      dest += WORD_SIZE;
+    }
+
+    if (len > 0) {
+      // left over bytes. Mask is used to remove unwanted bytes from the word
+      uint mask = 256 ** (WORD_SIZE - len) - 1;
+      assembly {
+        let srcpart := and(mload(src), not(mask)) // zero out src
+        let destpart := and(mload(dest), mask) // retrieve the bytes
+        mstore(dest, or(destpart, srcpart))
+      }
+    }
+  }
+}

--- a/extension/packages/hardhat/contracts/RandomGenerator.sol
+++ b/extension/packages/hardhat/contracts/RandomGenerator.sol
@@ -1,0 +1,36 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "./RLPReader.sol";
+
+contract RandomGenerator {
+  using RLPReader for RLPReader.RLPItem;
+  using RLPReader for bytes;
+
+  uint256 public constant futureBlocks = 2;
+
+  uint256 public blockNumber;
+  uint256 public randomNumber;
+
+  function generateRandomNumber() public {
+    blockNumber = block.number;
+  }
+
+  function getRandomNumber(bytes memory rlpBytes) public {
+    require(block.number >= blockNumber + futureBlocks, "Future block not reached");
+    require(block.number < blockNumber + futureBlocks + 256, "You miss the window");
+
+    RLPReader.RLPItem[] memory ls = rlpBytes.toRlpItem().toList();
+
+    bytes memory mixHash = ls[13].toBytes();
+
+    uint256 blockNumberFromHeader = ls[8].toUint();
+
+    require(blockNumberFromHeader == blockNumber + futureBlocks, "Wrong block");
+
+    require(blockhash(blockNumberFromHeader) == keccak256(rlpBytes), "Wrong block header");
+
+    bytes32 hash = keccak256(abi.encodePacked(mixHash, address(this), msg.sender));
+    randomNumber = uint256(hash);
+  }
+}

--- a/extension/packages/hardhat/deploy/01_deploy_random_generator.ts
+++ b/extension/packages/hardhat/deploy/01_deploy_random_generator.ts
@@ -1,0 +1,38 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+import { Contract, parseEther } from "ethers";
+
+/**
+ * Deploys a contract named "RandomGenerator" using the deployer account and
+ * constructor arguments set to the deployer address
+ *
+ * @param hre HardhatRuntimeEnvironment object.
+ */
+const deployRandomGenerator: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  /*
+    On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+
+    When deploying to live networks (e.g `yarn deploy --network sepolia`), the deployer account
+    should have sufficient balance to pay for the gas fees for contract creation.
+
+    You can generate a random account with `yarn generate` which will fill DEPLOYER_PRIVATE_KEY
+    with a random private key in the .env file (then used on hardhat.config.ts)
+    You can run the `yarn account` command to check your balance in every network.
+  */
+  const { deployer } = await hre.getNamedAccounts();
+  const { deploy } = hre.deployments;
+
+  await deploy("RandomGenerator", {
+    from: deployer,
+    log: true,
+    // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
+    // automatically mining the contract deployment transaction. There is no effect on live networks.
+    autoMine: true,
+  });
+};
+
+export default deployRandomGenerator;
+
+// Tags are useful if you have multiple deploy files and only want to run one of them.
+// e.g. yarn deploy --tags Randao
+deployRandomGenerator.tags = ["Randao"];

--- a/extension/packages/nextjs/app/randao/page.tsx
+++ b/extension/packages/nextjs/app/randao/page.tsx
@@ -42,98 +42,106 @@ const Randao: NextPage = () => {
   }, [blockNumber, futureBlocks]);
 
   const generateRandomNumber = async () => {
-    await writeAsync(
-      {
-        functionName: "generateRandomNumber",
-      },
-      {
-        onBlockConfirmation: (txnReceipt: any) => {
-          console.log("Transaction blockHash", txnReceipt.blockHash);
-          notification.success("Random number generated. Wait for the future block and get the number.");
+    try {
+      await writeAsync(
+        {
+          functionName: "generateRandomNumber",
         },
-      },
-    );
+        {
+          onBlockConfirmation: (txnReceipt: any) => {
+            console.log("Transaction blockHash", txnReceipt.blockHash);
+            notification.success("Random number generated. Wait for the future block and get the number.");
+          },
+        },
+      );
+    } catch (e) {
+      console.error("Error generating random number: ", e);
+    }
   };
 
   const getRandomNumber = async () => {
-    console.log("currentBlockNumber: ", currentBlockNumber);
-    console.log("targetBlockNumber: ", targetBlockNumber);
+    try {
+      console.log("currentBlockNumber: ", currentBlockNumber);
+      console.log("targetBlockNumber: ", targetBlockNumber);
 
-    const blockData = await publicClient.getBlock({ blockNumber: targetBlockNumber });
+      const blockData = await publicClient.getBlock({ blockNumber: targetBlockNumber });
 
-    console.log("blockData: ", blockData);
+      console.log("blockData: ", blockData);
 
-    const values: `0x${string}`[] = [];
-    values.push(blockData.parentHash);
-    values.push(blockData.sha3Uncles);
-    values.push(blockData.miner as `0x${string}`);
-    values.push(blockData.stateRoot);
-    values.push(blockData.transactionsRoot);
-    values.push(blockData.receiptsRoot);
-    values.push(blockData.logsBloom);
-    values.push(`0x${blockData.difficulty.toString(16)}`);
-    values.push(`0x${blockData.number.toString(16)}`);
-    values.push(`0x${blockData.gasLimit.toString(16)}`);
-    values.push(`0x${blockData.gasUsed.toString(16)}`);
-    values.push(`0x${blockData.timestamp.toString(16)}`);
-    values.push(blockData.extraData);
-    values.push(blockData.mixHash);
-    values.push(blockData.nonce);
-    if ("baseFeePerGas" in blockData && blockData.baseFeePerGas !== null) {
-      values.push(`0x${blockData.baseFeePerGas.toString(16)}`);
-    }
-    if ("withdrawalsRoot" in blockData && blockData.withdrawalsRoot !== undefined) {
-      values.push(blockData.withdrawalsRoot);
-    } else {
-      values.push("0x");
-    }
-    if ("blobGasUsed" in blockData && blockData.blobGasUsed !== undefined && blockData.blobGasUsed !== null) {
-      values.push(toHex(blockData.blobGasUsed));
-    }
-    if ("excessBlobGas" in blockData && blockData.excessBlobGas !== undefined && blockData.excessBlobGas !== null) {
-      values.push(toHex(blockData.excessBlobGas));
-    }
-    if (
-      "parentBeaconBlockRoot" in blockData &&
-      blockData.parentBeaconBlockRoot !== undefined &&
-      blockData.parentBeaconBlockRoot !== null
-    ) {
-      values.push(blockData.parentBeaconBlockRoot as `0x${string}`);
-    }
-
-    console.log("blockData values: ", values);
-    for (let i = 0; i < values.length; i++) {
-      if (values[i] === "0x0") {
-        values[i] = "0x";
+      const values: `0x${string}`[] = [];
+      values.push(blockData.parentHash);
+      values.push(blockData.sha3Uncles);
+      values.push(blockData.miner as `0x${string}`);
+      values.push(blockData.stateRoot);
+      values.push(blockData.transactionsRoot);
+      values.push(blockData.receiptsRoot);
+      values.push(blockData.logsBloom);
+      values.push(`0x${blockData.difficulty.toString(16)}`);
+      values.push(`0x${blockData.number.toString(16)}`);
+      values.push(`0x${blockData.gasLimit.toString(16)}`);
+      values.push(`0x${blockData.gasUsed.toString(16)}`);
+      values.push(`0x${blockData.timestamp.toString(16)}`);
+      values.push(blockData.extraData);
+      values.push(blockData.mixHash);
+      values.push(blockData.nonce);
+      if ("baseFeePerGas" in blockData && blockData.baseFeePerGas !== null) {
+        values.push(`0x${blockData.baseFeePerGas.toString(16)}`);
       }
-      if (values[i].length % 2 === 1) {
-        values[i] = ("0x0" + values[i].substring(2)) as `0x${string}`;
+      if ("withdrawalsRoot" in blockData && blockData.withdrawalsRoot !== undefined) {
+        values.push(blockData.withdrawalsRoot);
+      } else {
+        values.push("0x");
       }
-    }
-    console.log("blockData values after: ", values);
+      if ("blobGasUsed" in blockData && blockData.blobGasUsed !== undefined && blockData.blobGasUsed !== null) {
+        values.push(toHex(blockData.blobGasUsed));
+      }
+      if ("excessBlobGas" in blockData && blockData.excessBlobGas !== undefined && blockData.excessBlobGas !== null) {
+        values.push(toHex(blockData.excessBlobGas));
+      }
+      if (
+        "parentBeaconBlockRoot" in blockData &&
+        blockData.parentBeaconBlockRoot !== undefined &&
+        blockData.parentBeaconBlockRoot !== null
+      ) {
+        values.push(blockData.parentBeaconBlockRoot as `0x${string}`);
+      }
 
-    const rlpEncodedValues = toRlp(values);
-    console.log("blockData RLP: ", rlpEncodedValues);
+      console.log("blockData values: ", values);
+      for (let i = 0; i < values.length; i++) {
+        if (values[i] === "0x0") {
+          values[i] = "0x";
+        }
+        if (values[i].length % 2 === 1) {
+          values[i] = ("0x0" + values[i].substring(2)) as `0x${string}`;
+        }
+      }
+      console.log("blockData values after: ", values);
 
-    const blockHash = keccak256(rlpEncodedValues);
-    console.log("blockData hash: ", blockHash);
+      const rlpEncodedValues = toRlp(values);
+      console.log("blockData RLP: ", rlpEncodedValues);
 
-    if (blockHash !== blockData.hash) {
-      notification.error("Block hash mismatch");
-      return;
-    }
+      const blockHash = keccak256(rlpEncodedValues);
+      console.log("blockData hash: ", blockHash);
 
-    await writeAsync(
-      {
-        functionName: "getRandomNumber",
-        args: [rlpEncodedValues],
-      },
-      {
-        onBlockConfirmation: (txnReceipt: any) => {
-          console.log("Transaction blockHash", txnReceipt.blockHash);
+      if (blockHash !== blockData.hash) {
+        notification.error("Block hash mismatch");
+        return;
+      }
+
+      await writeAsync(
+        {
+          functionName: "getRandomNumber",
+          args: [rlpEncodedValues],
         },
-      },
-    );
+        {
+          onBlockConfirmation: (txnReceipt: any) => {
+            console.log("Transaction blockHash", txnReceipt.blockHash);
+          },
+        },
+      );
+    } catch (e) {
+      console.error("Error getting random number: ", e);
+    }
   };
 
   const getRandomNumberDisabled =

--- a/extension/packages/nextjs/app/randao/page.tsx
+++ b/extension/packages/nextjs/app/randao/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import type { NextPage } from "next";
+import { useBlockNumber } from "wagmi";
+import { useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
+import { useEffect, useState } from "react";
+import { createPublicClient, http, keccak256, toHex, toRlp } from "viem";
+import scaffoldConfig from "~~/scaffold.config";
+import { notification } from "~~/utils/scaffold-eth";
+
+const Randao: NextPage = () => {
+  const [targetBlockNumber, setTargetBlockNumber] = useState<bigint>();
+  const { data: currentBlockNumber } = useBlockNumber({ watch: true });
+
+  const publicClient = createPublicClient({
+    chain: scaffoldConfig.targetNetworks[0],
+    transport: http(),
+  });
+
+  const { writeContractAsync: writeAsync } = useScaffoldWriteContract("RandomGenerator");
+
+  const { data: futureBlocks } = useScaffoldReadContract({
+    contractName: "RandomGenerator",
+    functionName: "futureBlocks",
+  });
+
+  const { data: blockNumber } = useScaffoldReadContract({
+    contractName: "RandomGenerator",
+    functionName: "blockNumber",
+  });
+
+  const { data: randomNumber } = useScaffoldReadContract({
+    contractName: "RandomGenerator",
+    functionName: "randomNumber",
+  });
+
+  useEffect(() => {
+    if (blockNumber && futureBlocks) {
+      setTargetBlockNumber(blockNumber + futureBlocks);
+    }
+  }, [blockNumber, futureBlocks]);
+
+  const generateRandomNumber = async () => {
+    await writeAsync(
+      {
+        functionName: "generateRandomNumber",
+      },
+      {
+        onBlockConfirmation: (txnReceipt: any) => {
+          console.log("Transaction blockHash", txnReceipt.blockHash);
+          notification.success("Random number generated. Wait for the future block and get the number.");
+        },
+      },
+    );
+  }
+
+  const getRandomNumber = async () => {
+    console.log("currentBlockNumber: ", currentBlockNumber);
+    console.log("targetBlockNumber: ", targetBlockNumber);
+
+    const blockData = await publicClient.getBlock({ blockNumber: targetBlockNumber });
+
+    console.log("blockData: ", blockData);
+
+    const values: `0x${string}`[] = [];
+    values.push(blockData.parentHash);
+    values.push(blockData.sha3Uncles);
+    values.push(blockData.miner as `0x${string}`);
+    values.push(blockData.stateRoot);
+    values.push(blockData.transactionsRoot);
+    values.push(blockData.receiptsRoot);
+    values.push(blockData.logsBloom);
+    values.push(`0x${blockData.difficulty.toString(16)}`);
+    values.push(`0x${blockData.number.toString(16)}`);
+    values.push(`0x${blockData.gasLimit.toString(16)}`);
+    values.push(`0x${blockData.gasUsed.toString(16)}`);
+    values.push(`0x${blockData.timestamp.toString(16)}`);
+    values.push(blockData.extraData);
+    values.push(blockData.mixHash);
+    values.push(blockData.nonce);
+    if ("baseFeePerGas" in blockData && blockData.baseFeePerGas !== null) {
+      values.push(`0x${blockData.baseFeePerGas.toString(16)}`);
+    }
+    if ("withdrawalsRoot" in blockData && blockData.withdrawalsRoot !== undefined) {
+      values.push(blockData.withdrawalsRoot);
+    } else {
+      values.push("0x");
+    }
+    if ("blobGasUsed" in blockData && blockData.blobGasUsed !== undefined && blockData.blobGasUsed !== null) {
+      values.push(toHex(blockData.blobGasUsed));
+    }
+    if ("excessBlobGas" in blockData && blockData.excessBlobGas !== undefined && blockData.excessBlobGas !== null) {
+      values.push(toHex(blockData.excessBlobGas));
+    }
+    if (
+      "parentBeaconBlockRoot" in blockData &&
+      blockData.parentBeaconBlockRoot !== undefined &&
+      blockData.parentBeaconBlockRoot !== null
+    ) {
+      values.push(blockData.parentBeaconBlockRoot as `0x${string}`);
+    }
+
+    console.log("blockData values: ", values);
+    for (let i = 0; i < values.length; i++) {
+      if (values[i] === "0x0") {
+        values[i] = "0x";
+      }
+      if (values[i].length % 2 === 1) {
+        values[i] = ("0x0" + values[i].substring(2)) as `0x${string}`;
+      }
+    }
+    console.log("blockData values after: ", values);
+
+    const rlpEncodedValues = toRlp(values);
+    console.log("blockData RLP: ", rlpEncodedValues);
+
+    const blockHash = keccak256(rlpEncodedValues);
+    console.log("blockData hash: ", blockHash);
+
+    if (blockHash !== blockData.hash) {
+      notification.error("Block hash mismatch");
+      return;
+    }
+
+    await writeAsync(
+      {
+        functionName: "getRandomNumber",
+        args: [rlpEncodedValues],
+      },
+      {
+        onBlockConfirmation: (txnReceipt: any) => {
+          console.log("Transaction blockHash", txnReceipt.blockHash);
+        },
+      },
+    );
+  };
+
+  const getRandomNumberDisabled = currentBlockNumber === undefined || targetBlockNumber === undefined || currentBlockNumber <= targetBlockNumber;
+
+  return (
+    <>
+      <div className="flex items-center flex-col flex-grow pt-10">
+        <div className="px-5 text-center max-w-4xl">
+          <h1 className="text-4xl font-bold">On-chain randomness using RANDAO</h1>
+          <div>
+            <p>
+              This extension shows how to use on-chain randomness using RANDAO for truly on-chain unpredictable random sources.
+            </p>
+            <p>
+              Ethereum PoS introduces randomness using block.mixHash (prevRandao). Look at{" "}
+              <a
+                target="_blank"
+                href="https://eips.ethereum.org/EIPS/eip-4399"
+                className="underline font-bold text-nowrap"
+              >EIP-4399</a>{" "}
+              for more information.
+            </p>
+            <p className="mt-8">
+              The randomness must be generated in two steps:
+              <ol className="list-decimal">
+                <li className="mt-4">
+                  First, a block in the future must be set from where the block.mixHash value will be used as the random source.
+                  For this, the user has to call a function in our contract.
+                </li>
+                <li className="mt-4">
+                  Then, after this future block is mined, the user needs to call again to get the random number, passing the whole block header as the parameter.
+                  The function uses the block header and the block hash to validate the header and use the block.mixHash value as a randomness source.
+                </li>
+              </ol>
+            </p>
+            <p className="mt-8">
+              This strategy can be used to generate random numbers for games, lotteries, etc., but also to generate random traits for NFTs, for example, avoiding centralized oracles.
+            </p>
+            <p className="mt-8">
+              <em>Foundry Note:</em> if you are using Anvil from Foundry, the random number will always be the same because Anvil always sets mixHash to zero.
+            </p>
+          </div>
+
+          <div className="divider my-0" />
+
+          <h2 className="text-3xl font-bold mt-4">Testing the random generator</h2>
+
+          <div>
+            <p>Using the button below you can call <strong>Generate Random Number</strong>.</p>
+            <p>
+              The function on the contract will set a future block number (set to 2 blocks into the future) to generate the random number.
+            </p>
+            <p>
+              After this block is mined, you can call the <strong>Get Random Number</strong> button to get the random number.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex-grow bg-base-300 w-full mt-8 px-8 pt-6 pb-12">
+          <p className="text-center text-lg">
+            <button
+              className="btn btn-primary mt-2"
+              onClick={generateRandomNumber}
+            >
+              Generate Random Number
+            </button>
+          </p>
+          <p className="text-center text-lg">
+            Current Block Number: {currentBlockNumber?.toString()}
+          </p>
+          {targetBlockNumber && (
+            <p className="text-center text-lg">
+              Waiting for Block Number: {(targetBlockNumber + 1n).toString()}
+            </p>
+          )}
+          <p className="text-center text-lg">
+            <button
+              className="btn btn-primary mt-2"
+              onClick={getRandomNumber}
+              disabled={getRandomNumberDisabled}
+            >
+              Get Random Number
+            </button>
+          </p>
+          <p className="text-center text-lg">
+            Random Number: <strong>{randomNumber?.toString()}</strong>
+          </p>
+        </div>
+      </div >
+    </>
+  );
+};
+
+export default Randao;

--- a/extension/packages/nextjs/app/randao/page.tsx
+++ b/extension/packages/nextjs/app/randao/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import type { NextPage } from "next";
-import { useBlockNumber } from "wagmi";
-import { useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 import { useEffect, useState } from "react";
+import type { NextPage } from "next";
 import { createPublicClient, http, keccak256, toHex, toRlp } from "viem";
+import { useBlockNumber } from "wagmi";
+import { BanknotesIcon } from "@heroicons/react/24/outline";
+import { useScaffoldReadContract, useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
 import scaffoldConfig from "~~/scaffold.config";
 import { notification } from "~~/utils/scaffold-eth";
 
@@ -52,7 +53,7 @@ const Randao: NextPage = () => {
         },
       },
     );
-  }
+  };
 
   const getRandomNumber = async () => {
     console.log("currentBlockNumber: ", currentBlockNumber);
@@ -135,16 +136,18 @@ const Randao: NextPage = () => {
     );
   };
 
-  const getRandomNumberDisabled = currentBlockNumber === undefined || targetBlockNumber === undefined || currentBlockNumber <= targetBlockNumber;
+  const getRandomNumberDisabled =
+    currentBlockNumber === undefined || targetBlockNumber === undefined || currentBlockNumber <= targetBlockNumber;
 
   return (
     <>
-      <div className="flex items-center flex-col flex-grow pt-10">
+      <div className="flex items-center flex-col flex-grow pt-10 px-5">
         <div className="px-5 text-center max-w-4xl">
           <h1 className="text-4xl font-bold">On-chain randomness using RANDAO</h1>
           <div>
             <p>
-              This extension shows how to use on-chain randomness using RANDAO for truly on-chain unpredictable random sources.
+              This extension shows how to use on-chain randomness using RANDAO for truly on-chain unpredictable random
+              sources.
             </p>
             <p>
               Ethereum PoS introduces randomness using block.mixHash (prevRandao). Look at{" "}
@@ -152,27 +155,32 @@ const Randao: NextPage = () => {
                 target="_blank"
                 href="https://eips.ethereum.org/EIPS/eip-4399"
                 className="underline font-bold text-nowrap"
-              >EIP-4399</a>{" "}
+              >
+                EIP-4399
+              </a>{" "}
               for more information.
             </p>
-            <p className="mt-8">
-              The randomness must be generated in two steps:
+            <div className="mt-8">
+              <span className="font-semibold">The randomness must be generated in two steps:</span>
               <ol className="list-decimal">
                 <li className="mt-4">
-                  First, a block in the future must be set from where the block.mixHash value will be used as the random source.
-                  For this, the user has to call a function in our contract.
+                  First, a block in the future must be set from where the block.mixHash value will be used as the random
+                  source. For this, the user has to call a function in our contract.
                 </li>
                 <li className="mt-4">
-                  Then, after this future block is mined, the user needs to call again to get the random number, passing the whole block header as the parameter.
-                  The function uses the block header and the block hash to validate the header and use the block.mixHash value as a randomness source.
+                  Then, after this future block is mined, the user needs to call again to get the random number, passing
+                  the whole block header as the parameter. The function uses the block header and the block hash to
+                  validate the header and use the block.mixHash value as a randomness source.
                 </li>
               </ol>
+            </div>
+            <p className="mt-8">
+              This strategy can be used to generate random numbers for games, lotteries, etc., but also to generate
+              random traits for NFTs, for example, avoiding centralized oracles.
             </p>
             <p className="mt-8">
-              This strategy can be used to generate random numbers for games, lotteries, etc., but also to generate random traits for NFTs, for example, avoiding centralized oracles.
-            </p>
-            <p className="mt-8">
-              <em>Foundry Note:</em> if you are using Anvil from Foundry, the random number will always be the same because Anvil always sets mixHash to zero.
+              <em>Foundry Note:</em> if you are using Anvil from Foundry, the random number will always be the same
+              because Anvil always sets mixHash to zero.
             </p>
           </div>
 
@@ -181,47 +189,51 @@ const Randao: NextPage = () => {
           <h2 className="text-3xl font-bold mt-4">Testing the random generator</h2>
 
           <div>
-            <p>Using the button below you can call <strong>Generate Random Number</strong>.</p>
             <p>
-              The function on the contract will set a future block number (set to 2 blocks into the future) to generate the random number.
+              Using the button below you can call <strong>Generate Random Number</strong>.
             </p>
             <p>
-              After this block is mined, you can call the <strong>Get Random Number</strong> button to get the random number.
+              The function on the contract will set a future block number (set to 2 blocks into the future) to generate
+              the random number.
             </p>
+            <div className="flex flex-col">
+              <p className="my-0">
+                After this block is mined, you can call the <strong>Get Random Number</strong> button to get the random
+                number.
+              </p>
+              <div className="my-0">
+                (TIP: You can click the <BanknotesIcon className="h-4 w-4 inline" /> in top right corner to mine new
+                blocks)
+              </div>
+            </div>
           </div>
         </div>
 
         <div className="flex-grow bg-base-300 w-full mt-8 px-8 pt-6 pb-12">
           <p className="text-center text-lg">
-            <button
-              className="btn btn-primary mt-2"
-              onClick={generateRandomNumber}
-            >
+            <button className="btn btn-primary dark:btn-secondary mt-2" onClick={generateRandomNumber}>
               Generate Random Number
             </button>
           </p>
-          <p className="text-center text-lg">
-            Current Block Number: {currentBlockNumber?.toString()}
-          </p>
+          <p className="text-center text-lg">Current Block Number: {currentBlockNumber?.toString()}</p>
           {targetBlockNumber && (
-            <p className="text-center text-lg">
-              Waiting for Block Number: {(targetBlockNumber + 1n).toString()}
-            </p>
+            <p className="text-center text-lg">Waiting for Block Number: {(targetBlockNumber + 1n).toString()}</p>
           )}
           <p className="text-center text-lg">
             <button
-              className="btn btn-primary mt-2"
+              className="btn btn-primary dark:btn-secondary mt-2"
               onClick={getRandomNumber}
               disabled={getRandomNumberDisabled}
             >
               Get Random Number
             </button>
           </p>
-          <p className="text-center text-lg">
-            Random Number: <strong>{randomNumber?.toString()}</strong>
-          </p>
+          <div className="text-center text-lg break-all">
+            <p className="my-0">Random Number:</p>
+            <strong>{randomNumber?.toString()}</strong>
+          </div>
         </div>
-      </div >
+      </div>
     </>
   );
 };

--- a/extension/packages/nextjs/components/Header.tsx.args.mjs
+++ b/extension/packages/nextjs/components/Header.tsx.args.mjs
@@ -1,0 +1,6 @@
+export const menuIconImports = `import { CalculatorIcon } from "@heroicons/react/24/outline";`;
+export const menuObjects = `{
+  label: "RANDAO",
+  href: "/randao",
+  icon: <CalculatorIcon className="h-4 w-4" />,
+}`;


### PR DESCRIPTION
Extension implementing a random generator using RANDAO.

I tried to build this as simple and generic as possible, to keep in mind this can be used for different applications that need some randomness.

It's working on Foundry now (Foundry does not set the withdrawalsRoot header) but the random number generated is always the same because the mixHash field from the header (where the randomness is taken from) is always zero.

To install the extension on Foundry you have to use the new create-eth version, which has not been released yet.