### PR TITLE
Fix onchainkit

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,0 @@
-{
-  "resolutions": {
-    "@tanstack/react-query": "5.29.0",
-    "viem": "2.17.5",
-    "wagmi": "2.11.2"
-  }
-}

--- a/extension/packages/nextjs/app/onchainkit-examples/_components/OnchainKitTokens.tsx
+++ b/extension/packages/nextjs/app/onchainkit-examples/_components/OnchainKitTokens.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
-import { Token, TokenChip, TokenRow, TokenSearch, getTokens } from "@coinbase/onchainkit/token";
+import { getTokens } from "@coinbase/onchainkit/api";
+import { Token, TokenChip, TokenRow, TokenSearch } from "@coinbase/onchainkit/token";
 
 export const OnchainKitTokens = () => {
   const [filteredTokens, setFilteredTokens] = useState<Token[]>([]);

--- a/extension/packages/nextjs/package.json
+++ b/extension/packages/nextjs/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@coinbase/onchainkit": "^0.33.3",
     "@tanstack/react-query": "^5.59.0",
-    "viem": "^2.21.6",
+    "viem": "^2.21.17",
     "wagmi": "^2.12.16"
   }
 }

--- a/extension/packages/nextjs/package.json
+++ b/extension/packages/nextjs/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "@coinbase/onchainkit": "^0.26.3",
-    "@tanstack/react-query": "^5.29.0",
-    "viem": "^2.17.5",
-    "wagmi": "^2.11.2"
+    "@coinbase/onchainkit": "^0.33.3",
+    "@tanstack/react-query": "^5.59.0",
+    "viem": "^2.21.6",
+    "wagmi": "^2.12.16"
   }
 }


### PR DESCRIPTION
Up versions of deps 

onchainkit inner deps is
```
    "@tanstack/react-query": "^5",
    "viem": "^2.17.4",
    "wagmi": "^2.11.0"
```
so looks like nothing should break if they won't change major versions. Previously it could break because of intersection with `create-eth` versions of that deps, or because of fixed versions.


+ fixed one import after changing onchainkit version

---

To test

```
npx create-eth@latest -e scaffold-eth/create-eth-extensions:fix-onchainkit
```

---

note: asked Austin to add avatar to base ens, currently it looks like this
![photo_2024-10-02 19 14 39](https://github.com/user-attachments/assets/c96e7147-5101-4253-9b01-800a8debcad8)
