### PR TITLE
Updated graph-cli and graph-ts versions

### DIFF
--- a/extension/packages/subgraph/package.json
+++ b/extension/packages/subgraph/package.json
@@ -18,8 +18,8 @@
     "clean-node": "rm -rf graph-node/data/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "~0.55.0",
-    "@graphprotocol/graph-ts": "~0.31.0",
+    "@graphprotocol/graph-cli": "0.87.0",
+    "@graphprotocol/graph-ts": "0.35.1",
     "ts-node": "~10.9.1",
     "typescript": "~5.0.4"
   },


### PR DESCRIPTION
Updated versions of `graph-cli` and `graph-ts` to `v0.87.0` and `v0.35.1` respectively