### PR TITLE
remove apollo provider setup

### DIFF
--- a/extension/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.args.mjs
+++ b/extension/packages/nextjs/components/ScaffoldEthAppWithProviders.tsx.args.mjs
@@ -1,8 +1,0 @@
-export const providerNames = "ApolloProvider";
-export const providerSetups = `const subgraphUri = "http://localhost:8000/subgraphs/name/scaffold-eth/your-contract";
-  const apolloClient = new ApolloClient({
-    uri: subgraphUri,
-    cache: new InMemoryCache(),
-  });`;
-export const providerImports = `import { ApolloClient, ApolloProvider, InMemoryCache } from "@apollo/client";`;
-export const providerProps = "client={apolloClient}";


### PR DESCRIPTION
### Description: 

I think in #21 we moved away from apollo but forgot to remove the Apollo provider setup. This PR removes it.  

cc @kmjones1979 for testing and thanks for noticing it 🙌

### To test: 

```
npx create-eth@latest -e scaffold-eth/create-eth-extensions:subgraph-apollo
```