### PR TITLE
Updated dependencies to latest versions

### DIFF
--- a/extension/packages/nextjs/package.json
+++ b/extension/packages/nextjs/package.json
@@ -6,6 +6,6 @@
     "graphql": "~16.8.1"
   },
   "devDependencies": {
-    "@graphprotocol/client-cli": "^3.0.4"
+    "@graphprotocol/client-cli": "3.0.7"
   }
 }

--- a/extension/packages/subgraph/graph-node/docker-compose.yml
+++ b/extension/packages/subgraph/graph-node/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   graph-node:
-    image: graphprotocol/graph-node:v0.32.0
+    image: graphprotocol/graph-node:v0.36.0
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -22,7 +22,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   ipfs:
-    image: ipfs/go-ipfs:v0.10.0
+    image: ipfs/go-ipfs:v0.32.1
     ports:
       - "5001:5001"
     volumes:

--- a/extension/packages/subgraph/package.json
+++ b/extension/packages/subgraph/package.json
@@ -18,10 +18,10 @@
     "clean-node": "rm -rf graph-node/data/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "~0.55.0",
-    "@graphprotocol/graph-ts": "~0.31.0",
-    "ts-node": "~10.9.1",
-    "typescript": "~5.0.4"
+    "@graphprotocol/graph-cli": "0.93.3",
+    "@graphprotocol/graph-ts": "0.37.0",
+    "ts-node": "10.9.2",
+    "typescript": "5.7.2"
   },
   "devDependencies": {
     "@types/chalk": "^2.2.0",


### PR DESCRIPTION
Updated the following dependencies to the latest versions:

- `graphprotocol/client-cli`
- `graphprotocol/graph-node`
- `ipfs/go-ipfs`
- `graphprotocol/graph-cli`
- `graphprotocol/graph-ts`
- `ts-node`
- `typescript`