### PR TITLE
`subgraph` extension modules updated

### DIFF
--- a/extension/packages/subgraph/graph-node/docker-compose.yml
+++ b/extension/packages/subgraph/graph-node/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   graph-node:
-    image: graphprotocol/graph-node:v0.36.0
+    image: graphprotocol/graph-node:v0.36.1
     ports:
       - "8000:8000"
       - "8001:8001"

--- a/extension/packages/subgraph/graph-node/docker-compose.yml
+++ b/extension/packages/subgraph/graph-node/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       - "host.docker.internal:host-gateway"
   ipfs:
     image: ipfs/go-ipfs:v0.32.1
-    image: ipfs/go-ipfs:v0.32.1
     ports:
       - "5001:5001"
     volumes:

--- a/extension/packages/subgraph/package.json
+++ b/extension/packages/subgraph/package.json
@@ -13,7 +13,6 @@
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 scaffold-eth/your-contract",
     "local-ship": "yarn abi-copy && yarn codegen && yarn build --network localhost && yarn deploy-local",
     "test": "graph test -d",
-    "test": "graph test -d",
     "run-node": "cd graph-node && docker-compose up",
     "stop-node": "cd graph-node && docker-compose down",
     "clean-node": "rm -rf graph-node/data/"

--- a/extension/packages/subgraph/package.json
+++ b/extension/packages/subgraph/package.json
@@ -18,7 +18,7 @@
     "clean-node": "rm -rf graph-node/data/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.94.0",
+    "@graphprotocol/graph-cli": "0.95.0",
     "@graphprotocol/graph-ts": "0.37.0",
     "ts-node": "10.9.2",
     "typescript": "5.7.2"


### PR DESCRIPTION
Updated modules of `create-eth` `subgraph` extension. Here is a list of updated modules:
- `graph-cli` => `v0.95.0`
- `graph-node` => `v0.36.1`

To test, run:
```bash
npx create-eth@latest -e siddhant-k08/create-eth-extensions:subgraph
```