### PR TITLE
subgraph: updated dependencies

### DIFF
--- a/extension/packages/subgraph/graph-node/docker-compose.yml
+++ b/extension/packages/subgraph/graph-node/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   graph-node:
-    image: graphprotocol/graph-node:v0.36.1
+    image: graphprotocol/graph-node:v0.37.0
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -22,7 +22,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   ipfs:
-    image: ipfs/go-ipfs:v0.32.1
+    image: ipfs/go-ipfs:v0.33.2
     ports:
       - "5001:5001"
     volumes:

--- a/extension/packages/subgraph/package.json
+++ b/extension/packages/subgraph/package.json
@@ -18,8 +18,8 @@
     "clean-node": "rm -rf graph-node/data/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.95.0",
-    "@graphprotocol/graph-ts": "0.37.0",
+    "@graphprotocol/graph-cli": "0.96.0",
+    "@graphprotocol/graph-ts": "0.38.0",
     "ts-node": "10.9.2",
     "typescript": "5.7.2"
   },


### PR DESCRIPTION
Updated `graph-cli`, `graph-ts`, `graph-node` and `ipfs` to the latest versions.

To test:
```bash
yarn subgraph:test
```
