### PR TITLE
updated dependencies and fixed bug in `schema.graphql`

### DIFF
--- a/extension/packages/subgraph/graph-node/docker-compose.yml
+++ b/extension/packages/subgraph/graph-node/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   graph-node:
-    image: graphprotocol/graph-node:v0.36.1
+    image: graphprotocol/graph-node:v0.37.0
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -22,7 +22,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   ipfs:
-    image: ipfs/go-ipfs:v0.32.1
+    image: ipfs/go-ipfs:v0.34.1
     ports:
       - "5001:5001"
     volumes:

--- a/extension/packages/subgraph/package.json
+++ b/extension/packages/subgraph/package.json
@@ -18,8 +18,8 @@
     "clean-node": "rm -rf graph-node/data/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.95.0",
-    "@graphprotocol/graph-ts": "0.37.0",
+    "@graphprotocol/graph-cli": "0.97.0",
+    "@graphprotocol/graph-ts": "0.38.0",
     "ts-node": "10.9.2",
     "typescript": "5.7.2"
   },

--- a/extension/packages/subgraph/src/schema.graphql
+++ b/extension/packages/subgraph/src/schema.graphql
@@ -1,4 +1,4 @@
-type Greeting @entity {
+type Greeting @entity(immutable:true) {
   id: ID!
   sender: Sender!
   greeting: String!
@@ -8,7 +8,7 @@ type Greeting @entity {
   transactionHash: String!
 }
 
-type Sender @entity {
+type Sender @entity(immutable:true) {
   id: ID!
   address: Bytes!
   greetings: [Greeting!] @derivedFrom(field: "sender")


### PR DESCRIPTION
Updated the following dependencies:
- `graph-cli` => `v0.97.0`
- `graph-ts` => `v0.38.0`
- `graph-node` => `v0.37.0`
- `ipfs` => `v0.34.1`

Also, updated the `packages/subgraph/src/schema.graphql` file to mark the entities as immutable as per required in the [latest `graph-cli` release](https://github.com/graphprotocol/graph-tooling/releases/tag/%40graphprotocol%2Fgraph-cli%400.97.0).

To test, run: 
```bash
npx create-eth@latest -e siddhant-k08/create-eth-extensions:updateDependencies21April
```