### PR TITLE
Fix next config

### DIFF
--- a/extension/packages/nextjs/next.config.ts.args.mjs
+++ b/extension/packages/nextjs/next.config.ts.args.mjs
@@ -6,9 +6,7 @@ const {
 `
 
 export const configOverrides = {
-  experimental: {
-    serverComponentsExternalPackages: ["some-package"],
-  },
+  serverExternalPackages: ["some-package"],
 }
 
 export const postConfigContent = `


### PR DESCRIPTION
Fixes this warning when running `yarn start`

```
▲ Next.js 15.2.5
   - Local:        http://localhost:3000
   - Network:      http://192.168.88.194:3000

 ✓ Starting...
 ⚠ Invalid next.config.ts options detected: 
 ⚠     Unrecognized key(s) in object: 'serverComponentsExternalPackages' at "experimental"
 ⚠ See more info here: https://nextjs.org/docs/messages/invalid-next-config
 ⚠ `experimental.serverComponentsExternalPackages` has been moved to `serverExternalPackages`. Please update your next.config.ts file accordingly.
```