### PR TITLE
chore: updated `subgraph` modules

### DIFF
--- a/extension/packages/subgraph/graph-node/docker-compose.yml
+++ b/extension/packages/subgraph/graph-node/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   graph-node:
-    image: graphprotocol/graph-node:v0.37.0
+    image: graphprotocol/graph-node:v0.39.1
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -22,7 +22,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   ipfs:
-    image: ipfs/go-ipfs:v0.34.1
+    image: ipfs/go-ipfs:v0.36.0
     ports:
       - "5001:5001"
     volumes:

--- a/extension/packages/subgraph/package.json
+++ b/extension/packages/subgraph/package.json
@@ -18,8 +18,8 @@
     "clean-node": "rm -rf graph-node/data/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.97.0",
-    "@graphprotocol/graph-ts": "0.38.0",
+    "@graphprotocol/graph-cli": "0.97.1",
+    "@graphprotocol/graph-ts": "0.38.1",
     "ts-node": "10.9.2",
     "typescript": "5.7.2"
   },


### PR DESCRIPTION
Updated modules for the following:
- `graph-cli`: `graphprotocol/graph-cli: v0.97.0` => `graphprotocol/graph-cli: v0.97.1` (Find the release notes, [here](https://github.com/graphprotocol/graph-tooling/releases/tag/%40graphprotocol%2Fgraph-cli%400.97.1))

- `graph-ts`: `graphprotocol/graph-ts: v0.38.0` => `graphprotocol/graph-ts: v0.38.1` (Find the release notes, [here](https://github.com/graphprotocol/graph-tooling/releases/tag/%40graphprotocol%2Fgraph-ts%400.38.1))

- `graph-node`: `graphprotocol/graph-node: v0.37.0` => `graphprotocol/graph-node: v0.39.1` (Find the release notes, [here](https://github.com/graphprotocol/graph-node/releases/tag/v0.39.1))

- `ipfs`: `ipfs/go-ipfs:v0.34.1` => `ipfs/go-ipfs:v0.36.0` (Find the release notes, [here](https://github.com/ipfs/kubo/releases/tag/v0.36.0-rc1))

To test, run: 
```bash
npx create-eth@latest -e siddhant-k08/create-eth-extensions:moduleUpdate7
```