### PR TITLE
fix(eip-712): align Header args with create-eth template (use preContent + extraMenuLinksObjects)

### DIFF
--- a/extension/packages/nextjs/components/Header.tsx.args.mjs
+++ b/extension/packages/nextjs/components/Header.tsx.args.mjs
@@ -1,6 +1,8 @@
-export const menuIconImports = `import { DocumentCheckIcon } from "@heroicons/react/24/outline";`;
-export const menuObjects = `{
-  label: "EIP-712",
-  href: "/eip-712",
-  icon: <DocumentCheckIcon className="h-4 w-4" />,
-}`;
+export const preContent = `import { DocumentCheckIcon } from "@heroicons/react/24/outline";`;
+export const extraMenuLinksObjects = [
+  {
+    label: "EIP-712",
+    href: "/eip-712",
+    icon: '$$<DocumentCheckIcon className="h-4 w-4" />$$',
+  },
+];


### PR DESCRIPTION
When running `npx create-eth@latest -e eip-712` we're getting a mismatch in template arguments.

```
npx create-eth@latest -e eip-712

 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 | Create Scaffold-ETH 2 app |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+

✔ Your project name: my-dapp-example
✔ What solidity framework do you want to use? hardhat


✔ 📁 Create project directory /home/proofoftom/Code/web3/my-dapp-example
✖ Template templates/base/packages/nextjs/components/Header.tsx.template.mjs received unexpected argument `menuIconImports`. Expected only
  `preContent`, `extraMenuLinksObjects`, `logoTitle`, `logoSubtitle`
◼ 📦 Installing dependencies with yarn, this could take a while
◼ 🪄 Formatting files
◼ 📡 Initializing Git repository
ERROR Error occurred Error: Template templates/base/packages/nextjs/components/Header.tsx.template.mjs received unexpected argument `menuIconImports`. Expected only `preContent`, `extraMenuLinksObjects`, `logoTitle`, `logoSubtitle`
    at file:///home/proofoftom/.npm/_npx/85f97c58a7d429b9/node_modules/create-eth/templates/utils.js:79:15
    at Array.forEach (<anonymous>)
    at file:///home/proofoftom/.npm/_npx/85f97c58a7d429b9/node_modules/create-eth/templates/utils.js:77:31
    at file:///home/proofoftom/.npm/_npx/85f97c58a7d429b9/node_modules/create-eth/dist/cli.js:528:24
    at async Promise.all (index 9)
    at async processTemplatedFiles (file:///home/proofoftom/.npm/_npx/85f97c58a7d429b9/node_modules/create-eth/dist/cli.js:477:5)
    at async copyTemplateFiles (file:///home/proofoftom/.npm/_npx/85f97c58a7d429b9/node_modules/create-eth/dist/cli.js:605:5)
    at async Task.run (file:///home/proofoftom/.npm/_npx/85f97c58a7d429b9/node_modules/listr2/dist/index.js:1910:5)
Uh oh! 😕 Sorry about that! Exiting...
```


This PR fixes the template arg validation error by replacing unsupported keys and providing correct array shape.