### PR TITLE
chore: update subgraph modules

### DIFF
--- a/extension/packages/subgraph/graph-node/docker-compose.yml
+++ b/extension/packages/subgraph/graph-node/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   ipfs:
-    image: ipfs/go-ipfs:v0.39.0
+    image: ipfs/kubo:v0.39.0
     ports:
       - "5001:5001"
     volumes:

--- a/extension/packages/subgraph/graph-node/docker-compose.yml
+++ b/extension/packages/subgraph/graph-node/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   graph-node:
-    image: graphprotocol/graph-node:v0.37.0
+    image: graphprotocol/graph-node:v0.41.1
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -22,7 +22,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   ipfs:
-    image: ipfs/go-ipfs:v0.34.1
+    image: ipfs/go-ipfs:v0.39.0
     ports:
       - "5001:5001"
     volumes:

--- a/extension/packages/subgraph/package.json
+++ b/extension/packages/subgraph/package.json
@@ -18,8 +18,8 @@
     "clean-node": "rm -rf graph-node/data/"
   },
   "dependencies": {
-    "@graphprotocol/graph-cli": "0.97.0",
-    "@graphprotocol/graph-ts": "0.38.0",
+    "@graphprotocol/graph-cli": "0.98.1",
+    "@graphprotocol/graph-ts": "0.38.2",
     "ts-node": "10.9.2",
     "typescript": "5.7.2"
   },


### PR DESCRIPTION
Updated dependency versions for:

- `graph-cli`
- `graph-ts`
- `graph-node`
- `ipfs/kubo`

To test:
```
npx create-eth@latest -e siddhant-k08/create-eth-extensions:subgraph
```

and
```
yarn subgraph:test
```