### PR TITLE
drizzle-neon: use Uint8Array for fs.readSync buffers

### DIFF
--- a/extension/packages/nextjs/utils/prompt-confirm.ts
+++ b/extension/packages/nextjs/utils/prompt-confirm.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as fs from "fs";
 
-const buffer = Buffer.alloc(1);
+const buffer = new Uint8Array(1);
 fs.readSync(0, buffer, 0, 1, null);
 
 try {
-  const remaining = Buffer.alloc(1024);
+  const remaining = new Uint8Array(1024);
   fs.readSync(0, remaining, 0, 1024, null);
 } catch (error) {
   // Ignore any errors from trying to read remaining characters
@@ -13,5 +13,5 @@ try {
 
 process.stdout.write("\n");
 
-const answer = buffer.toString().toLowerCase();
+const answer = Buffer.from(buffer).toString().toLowerCase();
 process.exit(answer === "y" ? 0 : 1);


### PR DESCRIPTION
## Description: 

Buffer type no longer satisfies ArrayBufferView in newer Node.js/TypeScript. Replace Buffer.alloc() with Uint8Array() for read buffers.