### PR TITLE
fix: wagmiConfig override matches SE-2 main client + arbitrum

### DIFF
--- a/extension/packages/nextjs/services/web3/wagmiConfig.tsx.args.mjs
+++ b/extension/packages/nextjs/services/web3/wagmiConfig.tsx.args.mjs
@@ -3,19 +3,41 @@ import { arbitrum } from "viem/chains";
 `;
 
 export const configOverrides = {
-  client: `$$({chain})=>{const alchemyHttpUrl=chain.id==(arbitrum.id as number)?"http://127.0.0.1:8545":getAlchemyHttpUrl(chain.id);const rpcFallbacks=alchemyHttpUrl?[http(),http(alchemyHttpUrl)]:[http()];return createClient({chain,transport:fallback(rpcFallbacks)})}$$`,
+  client: `$$({chain})=>{const mainnetFallbackWithDefaultRPC=[http("https://mainnet.rpc.buidlguidl.com")];let rpcFallbacks=[...(chain.id===mainnet.id?mainnetFallbackWithDefaultRPC:[]),http()];if(chain.id===(arbitrum.id as number)){rpcFallbacks=[http("http://127.0.0.1:8545"),...rpcFallbacks];}const rpcOverrideUrl=(scaffoldConfig.rpcOverrides as ScaffoldConfig["rpcOverrides"])?.[chain.id];if(rpcOverrideUrl){rpcFallbacks=[http(rpcOverrideUrl),...rpcFallbacks];}else{const alchemyHttpUrl=getAlchemyHttpUrl(chain.id);if(alchemyHttpUrl){const isUsingDefaultKey=scaffoldConfig.alchemyApiKey===DEFAULT_ALCHEMY_API_KEY;rpcFallbacks=isUsingDefaultKey?[...rpcFallbacks,http(alchemyHttpUrl)]:[http(alchemyHttpUrl),...rpcFallbacks];}}return createClient({chain,transport:fallback(rpcFallbacks),...(chain.id!==(hardhat as Chain).id?{pollingInterval:scaffoldConfig.pollingInterval}:{})});}$$`,
 };
 
 // NOTE: While passing function you need to ensure it's in one line.
 // You can use AI to format the code to one line. (check above example for reference)
 /* export const configOverrides = {
   client: `$$({ chain }) => {
-    const alchemyHttpUrl = chain.id == arbitrum.id ? "http://127.0.0.1:8545" : getAlchemyHttpUrl(chain.id);
-    const rpcFallbacks = alchemyHttpUrl ? [http(), http(alchemyHttpUrl)] : [http()];
+    // Extra fallback for mainnet.
+    const mainnetFallbackWithDefaultRPC = [http("https://mainnet.rpc.buidlguidl.com")];
+    let rpcFallbacks = [...(chain.id === mainnet.id ? mainnetFallbackWithDefaultRPC : []), http()];
+
+    // Custom RPC for Arbitrum (extension example).
+    if (chain.id === (arbitrum.id as number)) {
+      rpcFallbacks = [http("http://127.0.0.1:8545"), ...rpcFallbacks];
+    }
+
+    const rpcOverrideUrl = (scaffoldConfig.rpcOverrides as ScaffoldConfig["rpcOverrides"])?.[chain.id];
+
+    if (rpcOverrideUrl) {
+      rpcFallbacks = [http(rpcOverrideUrl), ...rpcFallbacks];
+    } else {
+      const alchemyHttpUrl = getAlchemyHttpUrl(chain.id);
+      if (alchemyHttpUrl) {
+        const isUsingDefaultKey = scaffoldConfig.alchemyApiKey === DEFAULT_ALCHEMY_API_KEY;
+        // If using default Scaffold-ETH 2 API key, we prioritize the default RPC
+        rpcFallbacks = isUsingDefaultKey
+          ? [...rpcFallbacks, http(alchemyHttpUrl)]
+          : [http(alchemyHttpUrl), ...rpcFallbacks];
+      }
+    }
 
     return createClient({
       chain,
       transport: fallback(rpcFallbacks),
+      ...(chain.id !== (hardhat as Chain).id ? { pollingInterval: scaffoldConfig.pollingInterval } : {}),
     });
   }$$`
 } */


### PR DESCRIPTION
## Why

After scaffold-eth/create-eth's upcoming backmerge ([PR #427](https://github.com/scaffold-eth/create-eth/pull/427)), the generated nextjs uses next 16 + eslint-config-next 16, which enables a stricter \`@typescript-eslint/no-unused-vars\`. The current wagmiConfig override replaces the base client with a simpler function that doesn't reference \`hardhat\`, \`DEFAULT_ALCHEMY_API_KEY\`, or \`ScaffoldConfig\` — those become unused imports and \`yarn next:lint --max-warnings=0\` fails.

## What

Align the override with [scaffold-eth-2 main's wagmiConfig client](https://github.com/scaffold-eth/scaffold-eth-2/blob/main/packages/nextjs/services/web3/wagmiConfig.tsx) (rpcOverrides + isUsingDefaultKey RPC ordering + hardhat pollingInterval skip) and layer the arbitrum custom-RPC branch on top of it. Variable names and logic now match the scaffold main branch.

## Test plan

- [ ] Generate a project with this extension after create-eth's backmerge lands
- [ ] \`yarn next:lint --max-warnings=0\` exits 0
- [ ] Arbitrum One still routes to \`http://127.0.0.1:8545\` first

🤖 Generated with [Claude Code](https://claude.com/claude-code)